### PR TITLE
Correct vertex comparison in GraphVertex.GetNeighbors()

### DIFF
--- a/src/data-structures/graph/GraphVertex.ps1
+++ b/src/data-structures/graph/GraphVertex.ps1
@@ -51,7 +51,7 @@ class GraphVertex {
         $neighborsConverter = {
             param($node)
 
-            if ($node.value.startVertex.value -eq $this.value) {
+            if ($node.value.startVertex.getKey() -eq $this.getKey()) {
                 return $node.value.endVertex
             }
 

--- a/src/data-structures/graph/GraphVertex.ps1
+++ b/src/data-structures/graph/GraphVertex.ps1
@@ -51,7 +51,7 @@ class GraphVertex {
         $neighborsConverter = {
             param($node)
 
-            if ($node.value.startVertex -eq $this) {
+            if ($node.value.startVertex.value -eq $this.value) {
                 return $node.value.endVertex
             }
 


### PR DESCRIPTION
Hi Doug,

thanks first for this lib and your other contributions to Powershell.

I encountered a bug in the graph module at the example of the following graph:

```
# 1--2--3--5
#     `-4-´
#
$graph = New-Object Graph
$graph.addEdge([GraphEdge]::new([GraphVertex]::new("1"), [GraphVertex]::new("2"),1))
$graph.addEdge([GraphEdge]::new([GraphVertex]::new("2"), [GraphVertex]::new("3"),1))
$graph.addEdge([GraphEdge]::new([GraphVertex]::new("2"), [GraphVertex]::new("4"),1))
$graph.addEdge([GraphEdge]::new([GraphVertex]::new("3"), [GraphVertex]::new("5"),1))
$graph.addEdge([GraphEdge]::new([GraphVertex]::new("4"), [GraphVertex]::new("5"),1))

```

The adjancency matrix should be
```
#     1 2 3 4 5
#    __________
#  1 |∞ 1 ∞ ∞ ∞
#  2 |1 ∞ 1 1 ∞
#  3 |∞ 1 ∞ ∞ 1
#  4 |∞ 1 ∞ ∞ 1
#  5 |∞ ∞ 1 1 ∞
```

However, the code in the master branch outputs the following:

```
PS C:\Users\d90798\source> $graph.getAdjacencyMatrix() | %{ $_ -join ","}
∞,1,∞,∞,∞
1,1,∞,∞,∞
∞,1,1,∞,∞
∞,1,∞,1,∞
∞,∞,1,1,∞

```

The reason for this is, that you store copies of the vertices in the edges-linked lists, and those copied verices contain again edges (and those again vertices, and those again edges, and so on).

Now, when a new edge is inserted into the graph, the already stored edges are not updated. This leads to the fact, that theoretically identical vertices differ in the edges:

```
PS C:\Users\d90798\source> $graph.vertices[1]

value edges                        
----- -----                        
2     GraphEdge,GraphEdge,GraphEdge



PS C:\Users\d90798\source> $graph.vertices[2].edges.head.value.startVertex

value edges
----- -----
2      

```

I have not gone through the details of this storage scheme, and also don't want to change your code too much, but a possible approach could be to store references to vertices in the edges.

Yet, in the current pull request I only tried to fix the `getNeighbors()` function. The idea of the change is, that vertices compare identical if their IDs do, regardless of the edges, and thus I added the `.getKey()` methods. This then passes my tests of `getNeighbor()`, and also produces the correct adjacency matrix as shown above.

Best regards,
David
